### PR TITLE
Corrected hashing of UTF-8 strings.

### DIFF
--- a/bCrypt.js
+++ b/bCrypt.js
@@ -407,11 +407,11 @@ function ekskey(data, key, P, S) {
 		sw = streamtoword(data, offp);
 		offp = sw.offp;
 		lr[0] ^= sw.key;
-		
+
 		sw = streamtoword(data, offp);
 		offp = sw.offp;
 		lr[1] ^= sw.key;
-		
+
 		lr = encipher(lr, 0, P, S);
 		P[i] = lr[0];
 		P[i + 1] = lr[1];
@@ -420,11 +420,11 @@ function ekskey(data, key, P, S) {
 		sw = streamtoword(data, offp);
 		offp = sw.offp;
 		lr[0] ^= sw.key;
-		
+
 		sw = streamtoword(data, offp);
 		offp = sw.offp;
 		lr[1] ^= sw.key;
-		
+
 		lr = encipher(lr, 0, P, S);
 		S[i] = lr[0];
 		S[i + 1] = lr[1];
@@ -445,14 +445,14 @@ function crypt_raw(password, salt, log_rounds, progress) {
 
 	rounds = 1 << log_rounds;
 	one_percent = Math.floor(rounds / 100) + 1;
-	
+
 	var P = P_orig.slice();
 	var S = S_orig.slice();
-	
+
 	ekskey(salt, password, P, S);
 
 	var i = 0;
-	
+
 	while(true) {
 		if(i < rounds){
 			var start = new Date();
@@ -517,12 +517,14 @@ function hashpw(password, salt, progress) {
 	rounds = r1 + r2;
 	real_salt = salt.substring(off + 3, off + 25);
 	password = password + (minor >= 'a' ? "\000" : "");
-	for (var r = 0; r < password.length; r++) {
-		passwordb.push(getByte(password.charAt(r)));
+
+	var buf = new Buffer(password);
+	for (var r = 0; r < buf.length; r++) {
+		passwordb.push(buf[r]);
 	}
 	saltb = decode_base64(real_salt, BCRYPT_SALT_LEN);
 	var hashed = crypt_raw(passwordb, saltb, rounds, progress);
-	
+
 	var rs = [];
 	rs.push("$2");
 	if (minor >= 'a')
@@ -534,7 +536,7 @@ function hashpw(password, salt, progress) {
 	rs.push("$");
 	rs.push(encode_base64(saltb, saltb.length));
 	rs.push(encode_base64(hashed, bf_crypt_ciphertext.length * 4 - 1));
-	
+
 	return(rs.join(''));
 };
 
@@ -549,14 +551,14 @@ function gensalt(rounds) {
 		output.push("0");
 	output.push(iteration_count.toString());
 	output.push('$');
-	
+
 	var rand_buf;
 	try {
 		rand_buf = crypto.randomBytes(BCRYPT_SALT_LEN);
 	} catch (ex) {
 		throw ex;
 	}
-	
+
 	output.push(encode_base64(rand_buf, BCRYPT_SALT_LEN));
 	return output.join('');
 };
@@ -634,33 +636,33 @@ function compareSync(data, encrypted) {
 		data - [REQUIRED] - data to compare.
 		encrypted - [REQUIRED] - data to be compared to.
 	*/
-	
+
 	if(typeof data != "string" ||  typeof encrypted != "string") {
 		throw "Incorrect arguments";
 	}
-	
+
 	var encrypted_length = encrypted.length;
-	
+
 	if(encrypted_length != 60) {
 		throw "Not a valid BCrypt hash.";
 	}
-	
+
 	var same = true;
-	var hash_data = hashSync(data, encrypted.substr(0, encrypted_length-31));	
+	var hash_data = hashSync(data, encrypted.substr(0, encrypted_length-31));
 	var hash_data_length = hash_data.length;
-	
+
 	same = hash_data_length == encrypted_length;
-	
+
 	var max_length = (hash_data_length < encrypted_length) ? hash_data_length : encrypted_length;
 
 	// to prevent timing attacks, should check entire string
-	// don't exit after found to be false	
+	// don't exit after found to be false
 	for (var i = 0; i < max_length; ++i) {
 		if (hash_data_length >= i && encrypted_length >= i && hash_data[i] != encrypted[i]) {
 			same = false;
 		}
 	}
-	
+
 	return same;
 }
 

--- a/test-sync.js
+++ b/test-sync.js
@@ -1,3 +1,4 @@
+/*jslint node: true, indent: 4, stupid: true */
 var bCrypt = require("./bCrypt");
 
 console.log("\n\n Salts \n");
@@ -43,26 +44,55 @@ console.log(hash0);
 
 console.log("\n\n First Set of Compares \n");
 
-console.log(bCrypt.compareSync("super secret", hash1));
-console.log(bCrypt.compareSync("super secret", hash2));
-console.log(bCrypt.compareSync("super secret", hash5));
-console.log(bCrypt.compareSync("super secret", hash6));
-console.log(bCrypt.compareSync("super secret", hash9));
-console.log(bCrypt.compareSync("super secret", hash3));
-console.log(bCrypt.compareSync("super secret", hash4));
-console.log(bCrypt.compareSync("super secret", hash7));
-console.log(bCrypt.compareSync("super secret", hash8));
-console.log(bCrypt.compareSync("super secret", hash0));
+console.log(bCrypt.compareSync("super secret", hash1) ? 'PASSED' : 'FAILED');
+console.log(bCrypt.compareSync("super secret", hash2) ? 'PASSED' : 'FAILED');
+console.log(bCrypt.compareSync("super secret", hash5) ? 'PASSED' : 'FAILED');
+console.log(bCrypt.compareSync("super secret", hash6) ? 'PASSED' : 'FAILED');
+console.log(bCrypt.compareSync("super secret", hash9) ? 'PASSED' : 'FAILED');
+console.log(bCrypt.compareSync("super secret", hash3) ? 'FAILED' : 'PASSED');
+console.log(bCrypt.compareSync("super secret", hash4) ? 'FAILED' : 'PASSED');
+console.log(bCrypt.compareSync("super secret", hash7) ? 'FAILED' : 'PASSED');
+console.log(bCrypt.compareSync("super secret", hash8) ? 'FAILED' : 'PASSED');
+console.log(bCrypt.compareSync("super secret", hash0) ? 'FAILED' : 'PASSED');
 
 console.log("\n\n Second Set of Compares \n");
 
-console.log(bCrypt.compareSync("supersecret", hash1));
-console.log(bCrypt.compareSync("supersecret", hash2));
-console.log(bCrypt.compareSync("supersecret", hash5));
-console.log(bCrypt.compareSync("supersecret", hash6));
-console.log(bCrypt.compareSync("supersecret", hash9));
-console.log(bCrypt.compareSync("supersecret", hash3));
-console.log(bCrypt.compareSync("supersecret", hash4));
-console.log(bCrypt.compareSync("supersecret", hash7));
-console.log(bCrypt.compareSync("supersecret", hash8));
-console.log(bCrypt.compareSync("supersecret", hash0));
+console.log(bCrypt.compareSync("supersecret", hash1) ? 'FAILED' : 'PASSED');
+console.log(bCrypt.compareSync("supersecret", hash2) ? 'FAILED' : 'PASSED');
+console.log(bCrypt.compareSync("supersecret", hash5) ? 'FAILED' : 'PASSED');
+console.log(bCrypt.compareSync("supersecret", hash6) ? 'FAILED' : 'PASSED');
+console.log(bCrypt.compareSync("supersecret", hash9) ? 'FAILED' : 'PASSED');
+console.log(bCrypt.compareSync("supersecret", hash3) ? 'PASSED' : 'FAILED');
+console.log(bCrypt.compareSync("supersecret", hash4) ? 'PASSED' : 'FAILED');
+console.log(bCrypt.compareSync("supersecret", hash7) ? 'PASSED' : 'FAILED');
+console.log(bCrypt.compareSync("supersecret", hash8) ? 'PASSED' : 'FAILED');
+console.log(bCrypt.compareSync("supersecret", hash0) ? 'PASSED' : 'FAILED');
+
+
+console.log('\n\n -------------------- UTF-8 passwords --------------------');
+var pw1 = '\u6e2f',  // http://www.fileformat.info/info/unicode/char/6e2f/index.htm
+    pw2 = '港', // Character 0x6e2f same as pw1.
+    pw3 = '\u6f2f',  // http://www.fileformat.info/info/unicode/char/6f2f/index.htm
+    pw4 = '漯', // Character 0x6f2f same as pw3.
+    salt = '$2a$05$0000000000000000000000',
+    hash_pw1 = bCrypt.hashSync(pw1, salt, null),
+    hash_pw2 = bCrypt.hashSync(pw2, salt, null),
+    hash_pw3 = bCrypt.hashSync(pw3, salt, null),
+    hash_pw4 = bCrypt.hashSync(pw4, salt, null);
+
+console.log("\n\n Hashes \n");
+console.log(hash_pw1);
+console.log(hash_pw2);
+console.log(hash_pw3);
+console.log(hash_pw4);
+
+console.log("\n\n Third Set of Compares \n");
+
+console.log(bCrypt.compareSync(pw1, hash_pw1) ? 'PASSED' : 'FAILED');
+console.log(bCrypt.compareSync(pw2, hash_pw2) ? 'PASSED' : 'FAILED');
+console.log(bCrypt.compareSync(pw3, hash_pw3) ? 'PASSED' : 'FAILED');
+console.log(bCrypt.compareSync(pw4, hash_pw4) ? 'PASSED' : 'FAILED');
+console.log('Hashes 1 and 3 are different: ' + (hash_pw1 !== hash_pw3) ? 'PASSED' : 'FAILED');
+console.log('Hashes 2 and 4 are different: ' + (hash_pw2 !== hash_pw4) ? 'PASSED' : 'FAILED');
+console.log('Hashes 1 and 2 are the same: ' + (hash_pw1 !== hash_pw2) ? 'PASSED' : 'FAILED');
+console.log('Hashes 3 and 4 are the same: ' + (hash_pw3 !== hash_pw4) ? 'PASSED' : 'FAILED');


### PR DESCRIPTION
There was an issue with hashing string formed of multi-byte characters.
Only one of the byte of the character was taken into account when
building the hash. This fix solves the situation.

Unfortunately, this makes any non-latin passwords previously hashed by
the code obsolete and totally impossible to verify. Any password containing
UTF-8 multi-byte characters hashed with the previous version of the code
cannot be verified after this change is applied.

I recommend using this patch only if you are starting up a new project and to
keep using the old code version if you don't have the capability in your
project of having both versions in parallel until all your user's passwords
are rolled-over to the new hashing algorithm.

I added a unit test to demonstrate that the new algorithm works as
expected with multi-byte characters.
