### PR TITLE
Resolution to issue #11 as raised and debugged by dcodeIO

### DIFF
--- a/bCrypt.js
+++ b/bCrypt.js
@@ -617,9 +617,10 @@ function hash(data, salt, progress, callback) {
 			error - First parameter to the callback detailing any errors.
 			encrypted - Second parameter to the callback providing the encrypted form.
 	*/
-	if(!callback) {
-		throw "No callback function was given."
-	}
+    if(typeof callback == 'undefined') {
+        callback = progress;
+        progress = null;
+    }
 	process.nextTick(function() {
 		var result = null;
 		var error = null;


### PR DESCRIPTION
This improves bcrypt-nodejs compatability with the bcrypt package.  

i.e. when writing code against the bcrypt library, and changing libraries to use bcrypt-nodejs instead, node raises a runtime error which is resolved with this change.  
