### PR TITLE
bcrypt.compare* should return false on hashes of length != 60

### DIFF
--- a/bCrypt.js
+++ b/bCrypt.js
@@ -645,7 +645,7 @@ function compareSync(data, encrypted) {
 	var encrypted_length = encrypted.length;
 
 	if(encrypted_length != 60) {
-		throw "Not a valid BCrypt hash.";
+        return false;
 	}
 
 	var same = true;

--- a/test/async-test.js
+++ b/test/async-test.js
@@ -13,6 +13,8 @@ describe('Test Async', function () {
   this.slow('8s')
   var bacon = 'bacon'
   var veggies = 'veggies'
+  var soyBaconHash = 'some invalid hash that does not equal sixty bytes in length'
+
   var salt1, salt2, baconHash1, baconHash2, veggiesHash1, veggiesHash2
   before(function (done) {
     async.parallel([
@@ -140,4 +142,12 @@ describe('Test Async', function () {
       done()
     })
   })
+  it('soyBaconHash is just wrong and should return false and not throw', function(done) {
+    bCrypt.compare(veggies, soyBaconHash, function (err, matches) {
+      should.not.exist(err)
+      assert.ok(!matches, 'compare should return false')
+      done()
+    })
+  })
+
 })

--- a/test/sync-test.js
+++ b/test/sync-test.js
@@ -8,7 +8,7 @@ describe('Test Sync', function () {
 
   var salt1, salt2
   var secret = "super secret"
-  var hash1, hash2, hash3, hash4, hash5, hash6, hash7, hash8, hash9, hash0
+  var hash1, hash2, hash3, hash4, hash5, hash6, hash7, hash8, hash9, hash0, invalidHash
 
   var pw1, pw2, pw3, pw4, hash_pw1, hash_pw2, hash_pw3, hash_pw4
   before(function () {
@@ -28,6 +28,8 @@ describe('Test Sync', function () {
     hash8 = bCrypt.hashSync('supersecret', salt2, null)
     hash9 = bCrypt.hashSync('super secret', null, null)
     hash0 = bCrypt.hashSync('super secret', null, null)
+
+    invalidHash = 'some invalid hash that does not equal sixty bytes in length'
 
     pw1 = '\u6e2f'  // http://www.fileformat.info/info/unicode/char/6e2f/index.htm
     pw2 = '港' // Character 0x6e2f same as pw1.
@@ -94,5 +96,8 @@ describe('Test Sync', function () {
   })
   it('hash_pw3 should be equal hash_pw4', function () {
     hash_pw3.should.eql(hash_pw3, 'hash_pw3 should equal hash_pw4')
+  })
+  it('invalid hash should return false and not throw', function() {
+      bCrypt.compareSync('supersecret', invalidHash).should.be.false
   })
 })


### PR DESCRIPTION
The native version returns false for invalid hashes (of length != 60)
Tests included.
