### PR TITLE
Added hashSync overload that accepts rounds instead of salt instance

### DIFF
--- a/bCrypt.js
+++ b/bCrypt.js
@@ -602,6 +602,9 @@ function hashSync(data, salt, progress) {
 		data - [REQUIRED] - the data to be encrypted.
 		salt - [REQUIRED] - the salt to be used in encryption.
 	*/
+	if (salt && !isNaN(salt)) {
+		salt = genSaltSync(salt);
+	}
 	if(!salt) {
 		salt = genSaltSync();
 	}

--- a/test/sync-test.js
+++ b/test/sync-test.js
@@ -100,4 +100,11 @@ describe('Test Sync', function () {
   it('invalid hash should return false and not throw', function() {
       bCrypt.compareSync('supersecret', invalidHash).should.be.false
   })
+
+  it('should use specified number of rounds', function () {
+    var PASSWORD = 'super secret'
+    var hash = bCrypt.hashSync(PASSWORD, 12)
+    assert.ok(bCrypt.compareSync(PASSWORD, hash), 'compareSync should return true')
+  })
+
 })


### PR DESCRIPTION
**Outline**
I added an overload to the `hashSync` function that accepts the number of rounds to use.

**Benefit**
Instead of having to create a salt instance and pass it to the `hashSync` function:

``` JavaScript
var salt = bCrypt.genSaltSync(12);
var hash = bCrypt.hashSync('super secret', salt);
```

Consumers can now supply the number of rounds directly, as an argument:

```
var hash = bCrypt.hashSync('super secret', 12);
```

This is similar to how [**_node.bcrypt.js_**](https://github.com/ncb000gt/node.bcrypt.js) works.

**Todo**
- [ ] It would be wise to write a test that uses a spy to verify that the specified number of rounds are being used and not just the default.
- [ ] Document the overload in _README.md_.
- [ ] Document the overload in the `hashSync` comments.
- [ ] Bump version number

I am happy to do all these things, I just want to check that this is something that you would actually consider merging first. 

Thank you!
