### PR TITLE
:bug: Fix parameter handling in genSalt()

### DIFF
--- a/bCrypt.js
+++ b/bCrypt.js
@@ -577,14 +577,23 @@ function genSaltSync(rounds) {
 function genSalt(rounds, callback) {
 	/*
 		rounds - [OPTIONAL] - the number of rounds to process the data for. (default - 10)
-		seed_length - [OPTIONAL] - RAND_bytes wants a length. to make that a bit flexible, you can specify a seed_length. (default - 20)
 		callback - [REQUIRED] - a callback to be fired once the salt has been generated. uses eio making it asynchronous.
 			error - First parameter to the callback detailing any errors.
 			salt - Second parameter to the callback providing the generated salt.
 	*/
-	if(!callback) {
-		throw "No callback function was given."
-	}
+   if (typeof rounds !== 'number') {
+      if (typeof rounds !== 'function' || typeof callback !== 'undefined') {
+         throw 'getSalt() recieved a wrong input.';
+      } else {
+         callback = rounds;
+         rounds = GENSALT_DEFAULT_LOG2_ROUNDS;
+      }
+   } else {
+      if (typeof callback !== 'function') {
+         throw "No callback function was given.";
+      }
+   }
+
 	process.nextTick(function() {
 		var result = null;
 		var error = null;


### PR DESCRIPTION
According to the documentation, the `rounds` parameter in `genSalt()` should have a default value of 10. What I understand by reading that is that if there is only the callback function as a parameter, then the function would assign the default value to `rounds` and the callback function provided to `callback`. The code was throwing an error when this was done.

I replaced the parameter handling inside `genSalt()` to deal with this situation.