### PR TITLE
Fix tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
         "crypto"
     ],
     "devDependencies": {
+        "debug": "~2.2.0",
         "mocha": "~1.8.2",
         "should": "~1.2.2",
         "eyespect": "~0.1.8",


### PR DESCRIPTION
Travis builds for node 0.6 were failing because one of mocha's dependencies ([debug](https://github.com/visionmedia/debug)) released a minor version update (2.2.0 --> 2.6.3).

The newer version of the debug package used the `._extend` method which isn't available in node 0.6. 

On a separate note, I think at this point we can safely cut support for 0.6. Submitting another PR to update the versions of node we use for travis builds. 